### PR TITLE
Enhancement: Use ergebnis/composer-normalize instead of localheinz/composer-normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "phpstan/phpstan": "^0.11.1"
   },
   "require-dev": {
+    "ergebnis/composer-normalize": "^2.1.1",
     "jakub-onderka/php-parallel-lint": "^1.0",
-    "localheinz/composer-normalize": "~0.9.0",
     "phing/phing": "^2.16.0",
     "phpstan/phpstan-strict-rules": "^0.11",
     "spryker/code-sniffer": "^0.14",


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/composer-normalize` instead of `localheinz/composer-normalize`

Related to https://github.com/ergebnis/composer-normalize/issues/266.

💁‍♂ For reference, see https://localheinz.com/blog/2019/12/10/from-localheinz-to-ergebnis/.