### PR TITLE
Fixed cache methods issue. Fixed parameter type and return type errors for the  rule.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=7.2",
-    "phpstan/phpstan": "^0.12.0"
+    "phpstan/phpstan": "^0.12.4"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.1.1",

--- a/src/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRule.php
+++ b/src/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRule.php
@@ -29,7 +29,7 @@ class DynamicMethodMissingPhpDocAnnotationRule implements Rule
 
     /**
      * @param string $className
-     * @param array $methodNames
+     * @param string[] $methodNames
      */
     public function __construct(string $className, array $methodNames)
     {
@@ -37,9 +37,6 @@ class DynamicMethodMissingPhpDocAnnotationRule implements Rule
         $this->methodNames = $methodNames;
     }
 
-    /**
-     * @return string
-     */
     public function getNodeType(): string
     {
         return MethodCall::class;

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -14,3 +14,7 @@ parameters:
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
     ignoreErrors:
+        -
+            message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\MethodCall\\) of method PHPStan\\\\Rules\\\\Spryker\\\\DynamicMethodMissingPhpDocAnnotationRule\\:\\:processNode\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method PHPStan\\\\Rules\\\\Rule\\<PhpParser\\\\Node\\>\\:\\:processNode\\(\\)$#"
+            count: 1
+            path: ../src/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRule.php


### PR DESCRIPTION
Version 0.12.4 because of these [changes](https://github.com/phpstan/phpstan-src/commit/eeae2da7999b2e8b7b04542c6175d46f80c6d0b9).