### PR TITLE
FRW-998 Switched PHP version from 7.3 to 8.0 by default, enabled support of PHP 8.1 and 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '7.3', '8.2' ]
+        php-version: [ '8.1', '8.2' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '7.3' ]
+        php-version: [ '8.0' ]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spryker PHPStan Extensions
 [![Build Status](https://github.com/spryker-sdk/phpstan-spryker/workflows/CI/badge.svg?branch=master)](https://github.com/spryker-sdk/phpstan-spryker/actions?query=workflow%3ACI+branch%3Amaster)
-[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%207.3-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg)](https://php.net/)
 [![License](https://poser.pugx.org/spryker/code-sniffer/license.svg)](https://packagist.org/packages/spryker-sdk/phpstan-spryker)
 
 * [PHPStan](https://github.com/phpstan/phpstan)

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.0",
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=8.0",
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "~1.9.0"
+        "phpstan/phpstan": "1.9.16"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.1.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=8.0",
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "1.9.16"
+        "phpstan/phpstan": "^1.0.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.1.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=8.0",
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.0.0"
+        "phpstan/phpstan": "~1.9.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.1.1",

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,15 +1,6 @@
 includes:
     - ../vendor/phpstan/phpstan-strict-rules/rules.neon
 
-services:
-    scopeIsInClass:
-        class: PHPStan\Internal\ScopeIsInClassTypeSpecifyingExtension
-        arguments:
-            isInMethodName: isInClass
-            removeNullMethodName: getClassReflection
-        tags:
-            - phpstan.typeSpecifier.methodTypeSpecifyingExtension
-
 parameters:
     checkMissingIterableValueType: false
     ignoreErrors:


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/FRW-998
- RG: https://release.spryker.com/release-groups/view/5084