### PR TITLE
FRW-8801 Dropped PHP 8.0 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.1', '8.2' ]
+        php-version: [ '8.2', '8.3' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.0' ]
+        php-version: [ '8.1' ]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spryker PHPStan Extensions
 [![Build Status](https://github.com/spryker-sdk/phpstan-spryker/workflows/CI/badge.svg?branch=master)](https://github.com/spryker-sdk/phpstan-spryker/actions?query=workflow%3ACI+branch%3Amaster)
-[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
 [![License](https://poser.pugx.org/spryker/code-sniffer/license.svg)](https://packagist.org/packages/spryker-sdk/phpstan-spryker)
 
 * [PHPStan](https://github.com/phpstan/phpstan)

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.0.0"
     },

--- a/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
+++ b/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
@@ -19,9 +19,8 @@ class DynamicMethodMissingTypeExtensionTest extends TestCase
      */
     public function testInstance(): void
     {
-        $extension = $this->getMockBuilder(AnnotationsMethodsClassReflectionExtension::class)->disableOriginalConstructor()->getMock();
         $cache = $this->getMockBuilder(Cache::class)->disableOriginalConstructor()->getMock();
-        $instance = new DynamicMethodMissingTypeExtension($extension, $cache, 'test', []);
+        $instance = new DynamicMethodMissingTypeExtension(new AnnotationsMethodsClassReflectionExtension(), $cache, 'test', []);
         $this->assertInstanceOf(DynamicMethodMissingTypeExtension::class, $instance);
     }
 }

--- a/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
+++ b/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
@@ -8,6 +8,7 @@
 namespace SprykerSdk\PHPStanSpryker\Test\Rules\Spryker;
 
 use PHPStan\Cache\Cache;
+use PHPStan\Cache\CacheStorage;
 use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
 use SprykerSdk\PHPStanSpryker\Type\Spryker\DynamicMethodMissingTypeExtension;
 use PHPUnit\Framework\TestCase;
@@ -21,7 +22,7 @@ class DynamicMethodMissingTypeExtensionTest extends TestCase
     {
         $instance = new DynamicMethodMissingTypeExtension(
             new AnnotationsMethodsClassReflectionExtension(),
-            new Cache(),
+            new Cache($this->createMock(CacheStorage::class)),
             'test',
             []
         );

--- a/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
+++ b/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
@@ -19,8 +19,12 @@ class DynamicMethodMissingTypeExtensionTest extends TestCase
      */
     public function testInstance(): void
     {
-        $cache = $this->getMockBuilder(Cache::class)->disableOriginalConstructor()->getMock();
-        $instance = new DynamicMethodMissingTypeExtension(new AnnotationsMethodsClassReflectionExtension(), $cache, 'test', []);
+        $instance = new DynamicMethodMissingTypeExtension(
+            new AnnotationsMethodsClassReflectionExtension(),
+            new Cache(),
+            'test',
+            []
+        );
         $this->assertInstanceOf(DynamicMethodMissingTypeExtension::class, $instance);
     }
 }


### PR DESCRIPTION
- Developer(s): @olhalivitchuk  

- Ticket: https://spryker.atlassian.net/browse/FRW-8801

- Release Group: https://release.spryker.com/release-groups/view/5551

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   PhpstanSpryker             | patch (currently 0.x)          |                       |

-----------------------------------------

#### Module PhpstanSpryker

##### Change log

Improvements 

- Added `PHP 8.3` support.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
