### PR TITLE
FRW-8773 Added PHP Unit 11 support. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.1' ]
+        php-version: [ '8.2' ]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spryker PHPStan Extensions
 [![Build Status](https://github.com/spryker-sdk/phpstan-spryker/workflows/CI/badge.svg?branch=master)](https://github.com/spryker-sdk/phpstan-spryker/actions?query=workflow%3ACI+branch%3Amaster)
-[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%208.2-8892BF.svg)](https://php.net/)
 [![License](https://poser.pugx.org/spryker/code-sniffer/license.svg)](https://packagist.org/packages/spryker-sdk/phpstan-spryker)
 
 * [PHPStan](https://github.com/phpstan/phpstan)

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "phpunit/phpunit": "^11.3",
+        "phpunit/phpunit": "^11.4.0",
         "phpstan/phpstan": "^1.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^11.3",
         "phpstan/phpstan": "^1.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
- Developer(s): @olhalivitchuk

- Ticket: https://spryker.atlassian.net/browse/FRW-8773

- Release Group: https://release.spryker.com/release-groups/view/5594

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   PhpstanSpryker        | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module PhpstanSpryker

##### Change log

Improvements
- Added PHPUnit `v11` support.
- Increased the minimum required `PHP` version to 8.2.

Adjustments
- Increased `phpunit/phpunit` module version dependency.