### PR TITLE
Move phpunit/phpunit to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": ">=8.2",
-        "phpunit/phpunit": "^11.4.0",
         "phpstan/phpstan": "^1.0.0"
     },
     "require-dev": {
@@ -23,6 +22,7 @@
         "jakub-onderka/php-parallel-lint": "^1.0",
         "phing/phing": "^2.16.0",
         "phpstan/phpstan-strict-rules": "^1.0.0",
+        "phpunit/phpunit": "^11.4.0",
         "spryker/code-sniffer": "*",
         "squizlabs/php_codesniffer": "^3.6.0"
     },


### PR DESCRIPTION
PHPUnit is not required to run your package. It's only used when the package is developed.  
In the current state, it can cause conflicts with the PHPUnit version of the projects that use this package.
