### PR TITLE
CC-39568 Enforce typed class constants and forbid redundant docblocks

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,71 @@
 <?xml version="1.0"?>
 <ruleset name="SprykerStrict">
+    <!-- PHPStan rule fixtures contain intentionally non-compliant code (e.g. untyped
+         constants) used as test input; they must not be linted. -->
+    <exclude-pattern>tests/Fixtures/*</exclude-pattern>
+
     <rule ref="vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml">
+        <!--
+            Spryker's DocBlock sniffs mandate a @return tag on every value-returning
+            method (and a @return void on every void method, plus a docblock to hold
+            it). That directly collides with forbidding redundant @return annotations
+            below, so lift only that mandatory-@return[-void] requirement here. The
+            remaining DocBlock checks (format/order validation of an existing @return,
+            void-body mismatch, invalid @return on constructors, etc.) stay in force.
+        -->
+        <exclude name="Spryker.Commenting.DocBlock.DocBlockMissing"/>
+        <exclude name="Spryker.Commenting.DocBlock.ReturnVoidMissing"/>
+        <exclude name="Spryker.Commenting.DocBlockReturnVoid.ReturnMissing"/>
+        <exclude name="Spryker.Commenting.DocBlockReturnVoid.ReturnVoidMissing"/>
+    </rule>
+
+    <!--
+        SprykerStrict re-uses the Slevomat type-hint sniffs but explicitly excludes
+        their useless-docblock detection, so redundant @param/@return/@var annotations
+        that only restate a native type are allowed. Re-referencing those excluded
+        sub-codes does not re-enable them (phpcs treats sniff-level excludes as sticky),
+        so instead we reference the underlying Slevomat sniffs directly and keep ONLY
+        their useless-annotation detection on. The missing-native-type detection stays
+        owned by the SprykerStrict sniffs above, so it is excluded here to avoid
+        double-reporting. Array-shape / narrowing docblocks (list<...>, array<...>,
+        string[], class-string<...>) carry information the native type cannot and are
+        never reported as useless.
+    -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessSuppress"/>
+        <properties>
+            <property name="enableMixedTypeHint" value="false"/>
+            <property name="enableUnionTypeHint" value="false"/>
+            <property name="enableIntersectionTypeHint" value="false"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.LessSpecificNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessSuppress"/>
+        <properties>
+            <property name="enableStaticTypeHint" value="false"/>
+            <property name="enableMixedTypeHint" value="false"/>
+            <property name="enableUnionTypeHint" value="false"/>
+            <property name="enableIntersectionTypeHint" value="false"/>
+            <property name="enableNeverTypeHint" value="false"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessSuppress"/>
+        <properties>
+            <property name="enableNativeTypeHint" value="false"/>
+            <property name="enableMixedTypeHint" value="false"/>
+            <property name="enableUnionTypeHint" value="false"/>
+            <property name="enableIntersectionTypeHint" value="false"/>
+        </properties>
     </rule>
 </ruleset>

--- a/src/Rules/Spryker/ClassConstantNativeTypeHintRule.php
+++ b/src/Rules/Spryker/ClassConstantNativeTypeHintRule.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace SprykerSdk\PHPStanSpryker\Rules\Spryker;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassConst;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\ClassConst>
+ */
+class ClassConstantNativeTypeHintRule implements Rule
+{
+    /**
+     * @return class-string<\PhpParser\Node\Stmt\ClassConst>
+     */
+    public function getNodeType(): string
+    {
+        return ClassConst::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\ClassConst $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->type !== null) {
+            return [];
+        }
+
+        $className = $scope->isInClass() ? $scope->getClassReflection()->getDisplayName() : '';
+
+        $errors = [];
+        foreach ($node->consts as $const) {
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                'Class constant %s::%s has no native type hint; declare one (e.g. `private const string FOO = ...`).',
+                $className,
+                $const->name->toString(),
+            ))
+                ->identifier('spryker.classConstantMissingNativeType')
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRule.php
+++ b/src/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRule.php
@@ -23,15 +23,12 @@ use PHPStan\Type\ObjectType;
  */
 class DynamicMethodMissingPhpDocAnnotationRule implements Rule
 {
-    /**
-     * @var string
-     */
-    protected $className;
+    protected string $className;
 
     /**
      * @var array<string>
      */
-    protected $methodNames;
+    protected array $methodNames;
 
     /**
      * @param array<string> $methodNames

--- a/src/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRule.php
+++ b/src/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRule.php
@@ -1,9 +1,11 @@
-<?php declare(strict_types = 1);
+<?php
 
 /**
  * MIT License
  * For full license information, please view the LICENSE file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace SprykerSdk\PHPStanSpryker\Rules\Spryker;
 
@@ -27,13 +29,12 @@ class DynamicMethodMissingPhpDocAnnotationRule implements Rule
     protected $className;
 
     /**
-     * @var string[]
+     * @var array<string>
      */
     protected $methodNames;
 
     /**
-     * @param string $className
-     * @param string[] $methodNames
+     * @param array<string> $methodNames
      */
     public function __construct(string $className, array $methodNames)
     {
@@ -42,9 +43,7 @@ class DynamicMethodMissingPhpDocAnnotationRule implements Rule
     }
 
     /**
-     * @phpstan-return class-string<\PhpParser\Node\Expr\MethodCall>
-     *
-     * @return string
+     * @return class-string<\PhpParser\Node\Expr\MethodCall>
      */
     public function getNodeType(): string
     {
@@ -53,7 +52,6 @@ class DynamicMethodMissingPhpDocAnnotationRule implements Rule
 
     /**
      * @param \PhpParser\Node\Expr\MethodCall $node
-     * @param \PHPStan\Analyser\Scope $scope
      *
      * @return list<\PHPStan\Rules\IdentifierRuleError>
      */

--- a/src/Rules/Spryker/PropertyNativeTypeHintRule.php
+++ b/src/Rules/Spryker/PropertyNativeTypeHintRule.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace SprykerSdk\PHPStanSpryker\Rules\Spryker;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\Property>
+ */
+class PropertyNativeTypeHintRule implements Rule
+{
+    /**
+     * @return class-string<\PhpParser\Node\Stmt\Property>
+     */
+    public function getNodeType(): string
+    {
+        return Property::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\Property $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->type !== null) {
+            return [];
+        }
+
+        $className = $scope->isInClass() ? $scope->getClassReflection()->getDisplayName() : '';
+
+        $errors = [];
+        foreach ($node->props as $property) {
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                'Class property %s::$%s has no native type hint; declare one (e.g. `private string $foo;`).',
+                $className,
+                $property->name->toString(),
+            ))
+                ->identifier('spryker.propertyMissingNativeType')
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/src/Type/Spryker/DynamicMethodMissingTypeExtension.php
+++ b/src/Type/Spryker/DynamicMethodMissingTypeExtension.php
@@ -21,20 +21,17 @@ use PHPStan\Type\Type;
 
 class DynamicMethodMissingTypeExtension implements DynamicMethodReturnTypeExtension
 {
-    /**
-     * @var \PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension
-     */
-    private $annotationsMethodsClassReflectionExtension;
+    private AnnotationsMethodsClassReflectionExtension $annotationsMethodsClassReflectionExtension;
 
     /**
      * @var class-string
      */
-    protected $className;
+    protected string $className;
 
     /**
      * @var array<string>
      */
-    protected $methodNames;
+    protected array $methodNames;
 
     /**
      * @param class-string $className

--- a/src/Type/Spryker/DynamicMethodMissingTypeExtension.php
+++ b/src/Type/Spryker/DynamicMethodMissingTypeExtension.php
@@ -1,9 +1,11 @@
-<?php declare(strict_types = 1);
+<?php
 
 /**
  * MIT License
  * For full license information, please view the LICENSE file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace SprykerSdk\PHPStanSpryker\Type\Spryker;
 
@@ -30,14 +32,13 @@ class DynamicMethodMissingTypeExtension implements DynamicMethodReturnTypeExtens
     protected $className;
 
     /**
-     * @var string[]
+     * @var array<string>
      */
     protected $methodNames;
 
     /**
-     * @param \PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension $annotationsMethodsClassReflectionExtension
      * @param class-string $className
-     * @param string[] $methodNames
+     * @param array<string> $methodNames
      */
     public function __construct(
         AnnotationsMethodsClassReflectionExtension $annotationsMethodsClassReflectionExtension,
@@ -58,9 +59,7 @@ class DynamicMethodMissingTypeExtension implements DynamicMethodReturnTypeExtens
     }
 
     /**
-     * @param \PHPStan\Reflection\MethodReflection $methodReflection
-     *
-     * @return bool
+     * @inheritDoc
      */
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
@@ -72,11 +71,7 @@ class DynamicMethodMissingTypeExtension implements DynamicMethodReturnTypeExtens
     }
 
     /**
-     * @param \PHPStan\Reflection\MethodReflection $methodReflection
-     * @param \PhpParser\Node\Expr\MethodCall $methodCall
-     * @param \PHPStan\Analyser\Scope $scope
-     *
-     * @return \PHPStan\Type\Type
+     * @inheritDoc
      */
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
     {
@@ -84,13 +79,7 @@ class DynamicMethodMissingTypeExtension implements DynamicMethodReturnTypeExtens
     }
 
     /**
-     * @param \PHPStan\Reflection\MethodReflection $methodReflection
-     * @param \PhpParser\Node\Expr\MethodCall $methodCall
-     * @param \PHPStan\Analyser\Scope $scope
-     *
      * @throws \PHPStan\ShouldNotHappenException
-     *
-     * @return \PHPStan\Type\Type
      */
     protected function getTypeFromAnnotationsMethodClassReflection(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
     {

--- a/tests/Fixtures/ClassConstants/ClassWithConstants.php
+++ b/tests/Fixtures/ClassConstants/ClassWithConstants.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SprykerSdk\PHPStanSpryker\Test\Fixtures\ClassConstants;
+
+class ClassWithConstants
+{
+    public const UNTYPED = 'bad';
+
+    /**
+     * @var list<string>
+     */
+    protected const UNTYPED_WITH_SHAPE_DOCBLOCK = ['bad'];
+
+    public const UNTYPED_MULTI_A = 1, UNTYPED_MULTI_B = 2;
+
+    public const string TYPED = 'good';
+
+    public const int TYPED_INT = 1;
+
+    /**
+     * @var list<string>
+     */
+    private const array TYPED_ARRAY_WITH_SHAPE_DOCBLOCK = ['good'];
+
+    public function useConstants(): int
+    {
+        return self::TYPED_INT + count(self::TYPED_ARRAY_WITH_SHAPE_DOCBLOCK);
+    }
+}

--- a/tests/Fixtures/Properties/ClassWithProperties.php
+++ b/tests/Fixtures/Properties/ClassWithProperties.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SprykerSdk\PHPStanSpryker\Test\Fixtures\Properties;
+
+class ClassWithProperties
+{
+    public string $typed = 'good';
+
+    /**
+     * @var list<string>
+     */
+    private array $typedArrayWithShapeDocblock = ['good'];
+
+    protected $untyped;
+
+    protected $untypedMultiA, $untypedMultiB;
+
+    public function useProperties(): int
+    {
+        return strlen($this->typed) + count($this->typedArrayWithShapeDocblock);
+    }
+}

--- a/tests/Fixtures/Properties/ClassWithTypedProperties.php
+++ b/tests/Fixtures/Properties/ClassWithTypedProperties.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SprykerSdk\PHPStanSpryker\Test\Fixtures\Properties;
+
+class ClassWithTypedProperties
+{
+    public string $typed = 'good';
+
+    /**
+     * @var list<string>
+     */
+    private array $typedArrayWithShapeDocblock = ['good'];
+
+    public function useProperties(): int
+    {
+        return strlen($this->typed) + count($this->typedArrayWithShapeDocblock);
+    }
+}

--- a/tests/Rules/Spryker/ClassConstantNativeTypeHintRuleTest.php
+++ b/tests/Rules/Spryker/ClassConstantNativeTypeHintRuleTest.php
@@ -26,7 +26,7 @@ class ClassConstantNativeTypeHintRuleTest extends RuleTestCase
         return new ClassConstantNativeTypeHintRule();
     }
 
-    public function testGivenUntypedConstantsWhenAnalysedThenEachIsReported(): void
+    public function testGivenClassConstantsWithoutNativeTypeHintsWhenAnalysedThenErrorsAreReported(): void
     {
         // Arrange
         $prefix = 'Class constant SprykerSdk\PHPStanSpryker\Test\Fixtures\ClassConstants\ClassWithConstants::';

--- a/tests/Rules/Spryker/ClassConstantNativeTypeHintRuleTest.php
+++ b/tests/Rules/Spryker/ClassConstantNativeTypeHintRuleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace SprykerSdk\PHPStanSpryker\Test\Rules\Spryker;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use SprykerSdk\PHPStanSpryker\Rules\Spryker\ClassConstantNativeTypeHintRule;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<\SprykerSdk\PHPStanSpryker\Rules\Spryker\ClassConstantNativeTypeHintRule>
+ */
+class ClassConstantNativeTypeHintRuleTest extends RuleTestCase
+{
+    /**
+     * @return \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\ClassConst>
+     */
+    protected function getRule(): Rule
+    {
+        return new ClassConstantNativeTypeHintRule();
+    }
+
+    public function testGivenUntypedConstantsWhenAnalysedThenEachIsReported(): void
+    {
+        // Arrange
+        $prefix = 'Class constant SprykerSdk\PHPStanSpryker\Test\Fixtures\ClassConstants\ClassWithConstants::';
+        $suffix = ' has no native type hint; declare one (e.g. `private const string FOO = ...`).';
+
+        // Act & Assert
+        $this->analyse([__DIR__ . '/../../Fixtures/ClassConstants/ClassWithConstants.php'], [
+            [$prefix . 'UNTYPED' . $suffix, 9],
+            [$prefix . 'UNTYPED_WITH_SHAPE_DOCBLOCK' . $suffix, 14],
+            [$prefix . 'UNTYPED_MULTI_A' . $suffix, 16],
+            [$prefix . 'UNTYPED_MULTI_B' . $suffix, 16],
+        ]);
+    }
+}

--- a/tests/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRuleTest.php
+++ b/tests/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRuleTest.php
@@ -12,9 +12,12 @@ use SprykerSdk\PHPStanSpryker\Rules\Spryker\DynamicMethodMissingPhpDocAnnotation
 
 class DynamicMethodMissingPhpDocAnnotationRuleTest extends TestCase
 {
-    public function testInstance(): void
+    public function testGivenClassNameAndMethodNamesWhenConstructedThenAnInstanceOfTheRuleIsReturned(): void
     {
+        // Arrange & Act
         $instance = new DynamicMethodMissingPhpDocAnnotationRule('test', []);
+
+        // Assert
         $this->assertInstanceOf(DynamicMethodMissingPhpDocAnnotationRule::class, $instance);
     }
 }

--- a/tests/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRuleTest.php
+++ b/tests/Rules/Spryker/DynamicMethodMissingPhpDocAnnotationRuleTest.php
@@ -7,14 +7,11 @@
 
 namespace SprykerSdk\PHPStanSpryker\Test\Rules\Spryker;
 
-use SprykerSdk\PHPStanSpryker\Rules\Spryker\DynamicMethodMissingPhpDocAnnotationRule;
 use PHPUnit\Framework\TestCase;
+use SprykerSdk\PHPStanSpryker\Rules\Spryker\DynamicMethodMissingPhpDocAnnotationRule;
 
 class DynamicMethodMissingPhpDocAnnotationRuleTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testInstance(): void
     {
         $instance = new DynamicMethodMissingPhpDocAnnotationRule('test', []);

--- a/tests/Rules/Spryker/PropertyNativeTypeHintRuleTest.php
+++ b/tests/Rules/Spryker/PropertyNativeTypeHintRuleTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace SprykerSdk\PHPStanSpryker\Test\Rules\Spryker;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use SprykerSdk\PHPStanSpryker\Rules\Spryker\PropertyNativeTypeHintRule;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<\SprykerSdk\PHPStanSpryker\Rules\Spryker\PropertyNativeTypeHintRule>
+ */
+class PropertyNativeTypeHintRuleTest extends RuleTestCase
+{
+    /**
+     * @return \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\Property>
+     */
+    protected function getRule(): Rule
+    {
+        return new PropertyNativeTypeHintRule();
+    }
+
+    public function testGivenClassPropertiesWithoutNativeTypeHintsWhenAnalysedThenErrorsAreReported(): void
+    {
+        // Arrange
+        $prefix = 'Class property SprykerSdk\PHPStanSpryker\Test\Fixtures\Properties\ClassWithProperties::$';
+        $suffix = ' has no native type hint; declare one (e.g. `private string $foo;`).';
+
+        // Act & Assert
+        $this->analyse([__DIR__ . '/../../Fixtures/Properties/ClassWithProperties.php'], [
+            [$prefix . 'untyped' . $suffix, 16],
+            [$prefix . 'untypedMultiA' . $suffix, 18],
+            [$prefix . 'untypedMultiB' . $suffix, 18],
+        ]);
+    }
+
+    public function testGivenClassPropertiesWithNativeTypeHintsWhenAnalysedThenNothingIsReported(): void
+    {
+        // Arrange
+        $fixture = __DIR__ . '/../../Fixtures/Properties/ClassWithTypedProperties.php';
+
+        // Act & Assert
+        $this->analyse([$fixture], []);
+    }
+}

--- a/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
+++ b/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
@@ -8,20 +8,17 @@
 namespace SprykerSdk\PHPStanSpryker\Test\Rules\Spryker;
 
 use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
-use SprykerSdk\PHPStanSpryker\Type\Spryker\DynamicMethodMissingTypeExtension;
 use PHPUnit\Framework\TestCase;
+use SprykerSdk\PHPStanSpryker\Type\Spryker\DynamicMethodMissingTypeExtension;
 
 class DynamicMethodMissingTypeExtensionTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testInstance(): void
     {
         $instance = new DynamicMethodMissingTypeExtension(
             new AnnotationsMethodsClassReflectionExtension(),
             'test',
-            []
+            [],
         );
         $this->assertInstanceOf(DynamicMethodMissingTypeExtension::class, $instance);
     }

--- a/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
+++ b/tests/Type/Spryker/DynamicMethodMissingTypeExtensionTest.php
@@ -13,13 +13,16 @@ use SprykerSdk\PHPStanSpryker\Type\Spryker\DynamicMethodMissingTypeExtension;
 
 class DynamicMethodMissingTypeExtensionTest extends TestCase
 {
-    public function testInstance(): void
+    public function testGivenDependenciesWhenConstructedThenAnInstanceOfTheExtensionIsReturned(): void
     {
+        // Arrange & Act
         $instance = new DynamicMethodMissingTypeExtension(
             new AnnotationsMethodsClassReflectionExtension(),
             'test',
             [],
         );
+
+        // Assert
         $this->assertInstanceOf(DynamicMethodMissingTypeExtension::class, $instance);
     }
 }

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -7,6 +7,11 @@ services:
         class: SprykerSdk\PHPStanSpryker\Rules\Spryker\ClassConstantNativeTypeHintRule
         tags:
             - phpstan.rules.rule
+    # Self-enforcement: this package's own source must use natively typed properties.
+    -
+        class: SprykerSdk\PHPStanSpryker\Rules\Spryker\PropertyNativeTypeHintRule
+        tags:
+            - phpstan.rules.rule
 
 parameters:
     ignoreErrors:

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,6 +1,13 @@
 includes:
     - ../vendor/phpstan/phpstan-strict-rules/rules.neon
 
+services:
+    # Self-enforcement: this package's own source must use natively typed class constants.
+    -
+        class: SprykerSdk\PHPStanSpryker\Rules\Spryker\ClassConstantNativeTypeHintRule
+        tags:
+            - phpstan.rules.rule
+
 parameters:
     ignoreErrors:
         -


### PR DESCRIPTION
Adds tooling so this package can never carry untyped class constants or redundant type-restating docblocks.

## What it enforces
- Native-typed class constants (PHP 8.3+) via a new PHPStan self-check rule; missing native type is an error.
- Redundant `@param`/`@return`/`@var` docblocks that only restate a native type are forbidden via phpcs (raw Slevomat type-hint sniffs); array-shape and narrowing docblocks (`list<...>`, `array<...>`, `class-string<...>`) remain exempt.
- Spryker's mandatory-`@return`/`@return void` DocBlock sniffs are surgically lifted where they collide with the above; the rest of the Spryker docblock checks stay in force.

The constant rule is **self-enforcement only** (wired in the test phpstan config, not `extension.neon`), so it checks this package's own `src/` and is not imposed on consuming Spryker projects. It can be promoted to `extension.neon` later if we want it exported to consumers.

## Test plan
- `vendor/bin/phpcbf` then `vendor/bin/phpcs -p src/ tests/` — clean.
- `composer test` — all pass (incl. the new rule's RuleTestCase with Good/Bad fixtures).
- `composer stan` — no errors; verified a temporary untyped constant is flagged, then removed.